### PR TITLE
[Fix] Correctly render form element inside chromium (closes #9)

### DIFF
--- a/bh20simplewebuploader/templates/form.html
+++ b/bh20simplewebuploader/templates/form.html
@@ -87,6 +87,9 @@
          padding: 1em;
          background: #F8F8F8;
          margin-bottom: 1em;
+         -webkit-column-break-inside: avoid; /* Chrome, Safari, Opera */
+         page-break-inside: avoid; /* Firefox */
+         break-inside: avoid;
      }
 
      .record label {


### PR DESCRIPTION
#### Describe the bug

In chromium, the form elements "get stuck between columns":
![screencapture-covid-19-genenetwork-org-1586803524598](https://user-images.githubusercontent.com/11820306/79149793-5884f700-7dd0-11ea-9b47-b7678c7fb1cf.png)
This PR fixes the visual bug by explicitly telling each column to `break` in order to stay in one piece[0]

#### To Reproduce

Go to http://covid-19.genenetwork.org/ in Chrome or Chromium

#### Expected behavior

The columns should stay together without being split

#### Screenshots

After fix:
![screencapture-localhost-5000-1586803819352](https://user-images.githubusercontent.com/11820306/79150185-fd073900-7dd0-11ea-8021-cc600f3d2f3f.png)


[0] https://css-tricks.com/almanac/properties/b/break-inside/