### PR TITLE
Add dropdown support to web uploader metadata form

### DIFF
--- a/bh20sequploader/bh20seq-options.yml
+++ b/bh20sequploader/bh20seq-options.yml
@@ -4,13 +4,14 @@
 # types.
 
 host_age_unit:
-  year: http://purl.obolibrary.org/obo/UO_0000036
-  month: http://purl.obolibrary.org/obo/UO_0000035
-  week: http://purl.obolibrary.org/obo/UO_0000035
-  day: http://purl.obolibrary.org/obo/UO_0000034
-  hour: http://purl.obolibrary.org/obo/UO_0000032
+  Years: http://purl.obolibrary.org/obo/UO_0000036
+  Months: http://purl.obolibrary.org/obo/UO_0000035
+  Weeks: http://purl.obolibrary.org/obo/UO_0000034
+  Days: http://purl.obolibrary.org/obo/UO_0000033
+  Hours: http://purl.obolibrary.org/obo/UO_0000032
 
 host_sex:
   Male: http://purl.obolibrary.org/obo/NCIT_C20197
   Female: http://purl.obolibrary.org/obo/NCIT_C27993
-  unknown: http://purl.obolibrary.org/obo/NCIT_C17998
+  Intersex: http://purl.obolibrary.org/obo/NCIT_C45908
+  Unknown: http://purl.obolibrary.org/obo/NCIT_C17998

--- a/bh20sequploader/bh20seq-options.yml
+++ b/bh20sequploader/bh20seq-options.yml
@@ -1,0 +1,16 @@
+# Contains suggested human-readable field values and their corresponding IRIs.
+# Keyed on the field names in the types in the schema. Relies on field names
+# being unique or at least using the same options in different containing
+# types.
+
+host_age_unit:
+  year: http://purl.obolibrary.org/obo/UO_0000036
+  month: http://purl.obolibrary.org/obo/UO_0000035
+  week: http://purl.obolibrary.org/obo/UO_0000035
+  day: http://purl.obolibrary.org/obo/UO_0000034
+  hour: http://purl.obolibrary.org/obo/UO_0000032
+
+host_sex:
+  Male: http://purl.obolibrary.org/obo/NCIT_C20197
+  Female: http://purl.obolibrary.org/obo/NCIT_C27993
+  unknown: http://purl.obolibrary.org/obo/NCIT_C17998

--- a/bh20sequploader/bh20seq-schema.yml
+++ b/bh20sequploader/bh20seq-schema.yml
@@ -30,7 +30,7 @@ $graph:
 #        jsonldPredicate:
 #          _id: http://purl.obolibrary.org/obo/NOMEN_0000037
     host_sex:
-        doc: Sex of the host as define in NCIT, IRI expected (http://purl.obolibrary.org/obo/C20197 (Male), http://purl.obolibrary.org/obo/NCIT_C27993 (Female) or unkown (http://purl.obolibrary.org/obo/NCIT_C17998))
+        doc: Sex of the host as defined in NCIT, IRI expected (http://purl.obolibrary.org/obo/NCIT_C20197 (Male), http://purl.obolibrary.org/obo/NCIT_C27993 (Female), http://purl.obolibrary.org/obo/NCIT_C45908 (Intersex), or http://purl.obolibrary.org/obo/NCIT_C17998 (Unknown))
         type: string
         jsonldPredicate:
           _id: http://purl.obolibrary.org/obo/PATO_0000047

--- a/bh20simplewebuploader/main.py
+++ b/bh20simplewebuploader/main.py
@@ -76,9 +76,6 @@ def generate_form(schema, options):
     IRI.
     """
 
-    print(schema)
-    print(options)
-
     # Get the list of form components, one of which is the root
     components = schema.get('$graph', [])
 
@@ -160,10 +157,7 @@ def generate_form(schema, options):
                 if ref_iri:
                     record['ref_iri'] = ref_iri
 
-                print(field_name)
-
                 if field_name in options:
-                    print("Has options: {}".format(options[field_name]))
                     # The field will be a 'select' type no matter what its real
                     # data type is.
                     record['type'] = 'select' # Not a real HTML input type. It's its own tag.

--- a/bh20simplewebuploader/main.py
+++ b/bh20simplewebuploader/main.py
@@ -7,7 +7,7 @@ import sys
 import re
 import string
 import yaml
-import urllib.request
+import pkg_resources
 from flask import Flask, request, redirect, send_file, send_from_directory, render_template
 
 import os.path
@@ -133,8 +133,8 @@ def generate_form(schema):
     return list(walk_fields(root_name))
 
 
-# At startup, we need to load the current metadata schema so we can make a form for it
-METADATA_SCHEMA = yaml.safe_load(urllib.request.urlopen('https://raw.githubusercontent.com/arvados/bh20-seq-resource/master/bh20sequploader/bh20seq-schema.yml'))
+# At startup, we need to load the metadata schema from the uploader module, so we can make a form for it
+METADATA_SCHEMA = yaml.safe_load(pkg_resources.resource_stream("bh20sequploader", "bh20seq-schema.yml"))
 FORM_ITEMS = generate_form(METADATA_SCHEMA)
 
 @app.route('/')

--- a/bh20simplewebuploader/main.py
+++ b/bh20simplewebuploader/main.py
@@ -25,7 +25,7 @@ app.config['MAX_CONTENT_LENGTH'] = 50 * 1024 * 1024
 @app.errorhandler(413)
 def handle_large_file(e):
     return (render_template('error.html',
-        error_message="One of your files is too large. The maximum file size is 1 megabyte."), 413)
+        error_message="One of your files is too large. The maximum file size is 50 megabytes."), 413)
 
 
 def type_to_heading(type_name):

--- a/bh20simplewebuploader/main.py
+++ b/bh20simplewebuploader/main.py
@@ -49,11 +49,11 @@ def name_to_label(field_name):
 
     return string.capwords(field_name.replace('_', ' '))
 
-def is_url(string):
+def is_iri(string):
     """
-    Return True if the given string looks like a URL, and False otherwise.
+    Return True if the given string looks like an IRI, and False otherwise.
 
-    Used for finding type URLs in the schema.
+    Used for finding type IRIs in the schema.
 
     Right now only supports http(s) URLs because that's all we have in our schema.
     """
@@ -101,7 +101,7 @@ def generate_form(schema):
         for field_name, field_type in by_name.get(type_name, {}).get('fields', {}).items():
             # For each field
 
-            ref_url = None
+            ref_iri = None
             if not isinstance(field_type, str):
                 # If the type isn't a string
 
@@ -113,15 +113,15 @@ def generate_form(schema):
                 # by the format, but if they occur, we might as well try to
                 # handle them.
                 if isinstance(predicate, str):
-                    if is_url(predicate):
-                        ref_url = predicate
+                    if is_iri(predicate):
+                        ref_iri = predicate
                 else:
                     # Assume it's a dict. Look at the fields we know about.
                     for field in ['_id', 'type']:
                         field_value = predicate.get(field, None)
-                        if isinstance(field_value, str) and is_url(field_value) and ref_url is None:
+                        if isinstance(field_value, str) and is_iri(field_value) and ref_iri is None:
                             # Take the first URL-looking thing we find
-                            ref_url = field_value
+                            ref_iri = field_value
                             break
 
 
@@ -146,8 +146,8 @@ def generate_form(schema):
                 record['id'] = '.'.join(parent_keys + [field_name])
                 record['label'] = name_to_label(field_name)
                 record['required'] = not optional and not subtree_optional
-                if ref_url:
-                    record['ref_url'] = ref_url
+                if ref_iri:
+                    record['ref_iri'] = ref_iri
                 if field_type == 'string':
                     record['type'] = 'text' # HTML input type
                 elif field_type == 'int':

--- a/bh20simplewebuploader/main.py
+++ b/bh20simplewebuploader/main.py
@@ -68,7 +68,8 @@ def generate_form(schema, options):
     form section in the template) or an 'id', 'label', 'type', and 'required'
     (in which case we make a form field in the template). Non-heading dicts
     with type 'select' will have an 'options' field, with a list of (name,
-    value) tuples, and represent a form dropdown element.
+    value) tuples, and represent a form dropdown element. Non-heading dicts may
+    have a human-readable 'docstring' field describing them.
 
     Takes the deserialized metadata schema YAML, and also a deserialized YAML
     of option values. The option values are keyed on (unscoped) field name in
@@ -110,8 +111,12 @@ def generate_form(schema, options):
             # For each field
 
             ref_iri = None
+            docstring = None
             if not isinstance(field_type, str):
                 # If the type isn't a string
+                
+                # It may have documentation
+                docstring = field_type.get('doc', None)
 
                 # See if it has a more info/what goes here URL
                 predicate = field_type.get('jsonldPredicate', {})
@@ -156,6 +161,8 @@ def generate_form(schema, options):
                 record['required'] = not optional and not subtree_optional
                 if ref_iri:
                     record['ref_iri'] = ref_iri
+                if docstring:
+                    record['docstring'] = docstring
 
                 if field_name in options:
                     # The field will be a 'select' type no matter what its real

--- a/bh20simplewebuploader/templates/form.html
+++ b/bh20simplewebuploader/templates/form.html
@@ -224,8 +224,8 @@
                         <label for="{{ record['id'] }}">
                             {{ record['label'] }}
                             {{ "*" if record['required'] else "" }}
-                            {% if 'ref_url' in record %}
-                            <a href="{{ record['ref_url'] }}" title="More Info" target="_blank">?</a>
+                            {% if 'ref_iri' in record %}
+                            <a href="{{ record['ref_iri'] }}" title="More Info" target="_blank">?</a>
                             {% endif %}
                         </label>
                         <input type="{{ record['type'] }}" id="{{ record['id'] }}" name="{{ record['id'] }}" {{ "required" if record['required'] else "" }}>

--- a/bh20simplewebuploader/templates/form.html
+++ b/bh20simplewebuploader/templates/form.html
@@ -224,7 +224,7 @@
                             {{ record['label'] }}
                             {{ "*" if record['required'] else "" }}
                             {% if 'ref_iri' in record %}
-                            <a href="{{ record['ref_iri'] }}" title="More Info" target="_blank">?</a>
+                            <a href="{{ record['ref_iri'] }}" title="{{ record.get('docstring', 'More Info') }}" target="_blank">?</a>
                             {% endif %}
                         </label>
                         {% if record['type'] == 'select' %}

--- a/bh20simplewebuploader/templates/form.html
+++ b/bh20simplewebuploader/templates/form.html
@@ -220,11 +220,11 @@
                     <div class="record">
                         <h4>{{ record['heading'] }}</h4>
                         {% else %}
-                        <label for="{{ record['id'] }}">
+                        <label for="{{ record['id'] }}" title="{{ record.get('docstring', '') }}">
                             {{ record['label'] }}
                             {{ "*" if record['required'] else "" }}
                             {% if 'ref_iri' in record %}
-                            <a href="{{ record['ref_iri'] }}" title="{{ record.get('docstring', 'More Info') }}" target="_blank">?</a>
+                            <a href="{{ record['ref_iri'] }}" target="_blank">?</a>
                             {% endif %}
                         </label>
                         {% if record['type'] == 'select' %}

--- a/bh20simplewebuploader/templates/form.html
+++ b/bh20simplewebuploader/templates/form.html
@@ -211,7 +211,6 @@
 
                 <div id="metadata_fill_form_spot">
                     <div id="metadata_fill_form">
-                        {{ record }}
                         {% for record in fields %}
 
                         {% if 'heading' in record %}
@@ -228,7 +227,16 @@
                             <a href="{{ record['ref_iri'] }}" title="More Info" target="_blank">?</a>
                             {% endif %}
                         </label>
+                        {% if record['type'] == 'select' %}
+                        <select id="{{ record['id'] }}" name="{{ record['id'] }}" {{ "required" if record['required'] else "" }}>
+                            <option value="" selected>Choose one...</option>
+                            {% for option in record['options'] %}
+                            <option value="{{ option[1] }}">{{ option[0] }}</option>
+                            {% endfor %}
+                        </select>
+                        {% else %}
                         <input type="{{ record['type'] }}" id="{{ record['id'] }}" name="{{ record['id'] }}" {{ "required" if record['required'] else "" }}>
+                        {% endif %}
                         {% endif %}
                         {% if loop.index == loop.length %}
                     </div>

--- a/bh20simplewebuploader/templates/form.html
+++ b/bh20simplewebuploader/templates/form.html
@@ -223,8 +223,11 @@
                         <label for="{{ record['id'] }}" title="{{ record.get('docstring', '') }}">
                             {{ record['label'] }}
                             {{ "*" if record['required'] else "" }}
+                            {% if 'docstring' in record %}
+                            <a href='javascript:alert({{ record['docstring'] | tojson }})'>❓</a>
+                            {% endif %}
                             {% if 'ref_iri' in record %}
-                            <a href="{{ record['ref_iri'] }}" target="_blank">?</a>
+                            <a href="{{ record['ref_iri'] }}" target="_blank" title="Ontology Link">🔗</a>
                             {% endif %}
                         </label>
                         {% if record['type'] == 'select' %}

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     author_email="peter.amstutz@curii.com",
     license="Apache 2.0",
     packages=["bh20sequploader", "bh20seqanalyzer", "bh20simplewebuploader"],
-    package_data={"bh20sequploader": ["bh20seq-schema.yml", "validation/formats"],
+    package_data={"bh20sequploader": ["bh20seq-schema.yml", "bh20seq-options.yml", "validation/formats"],
     },
     install_requires=install_requires,
     extras_require={


### PR DESCRIPTION
This adds support for dropdowns with restricted sets of values to the metadata upload form.

Just fill in `bh20sequploader/bh20seq-options.yml` with a record that looks like this, keyed on the field name you want to make into a dropdown, with filled with possible value -> IRI mappings:

```
host_age_unit:
  Years: http://purl.obolibrary.org/obo/UO_0000036
  Months: http://purl.obolibrary.org/obo/UO_0000035
  Weeks: http://purl.obolibrary.org/obo/UO_0000034
  Days: http://purl.obolibrary.org/obo/UO_0000033
  Hours: http://purl.obolibrary.org/obo/UO_0000032
```

It will then become a dropdown on the form:

![image](https://user-images.githubusercontent.com/5062495/79606408-696e8a80-80a6-11ea-9613-9b793861c7e3.png)
