### PR TITLE
from_genbank_to_fasta_and_yaml script update

### DIFF
--- a/scripts/dict_ontology_standardization/ncbi_countries.csv
+++ b/scripts/dict_ontology_standardization/ncbi_countries.csv
@@ -127,6 +127,7 @@ Hungary,http://www.wikidata.org/entity/Q28
 Iceland,http://www.wikidata.org/entity/Q189
 Icelandic Commonwealth,http://www.wikidata.org/entity/Q62389
 India,http://www.wikidata.org/entity/Q668
+India: Ahmedabad,http://www.wikidata.org/entity/Q1070
 India: Kerala State,http://www.wikidata.org/entity/Q1186
 India: Rajkot,http://www.wikidata.org/entity/Q1815245
 Indonesia,http://www.wikidata.org/entity/Q252
@@ -288,6 +289,7 @@ USA: KY,http://www.wikidata.org/entity/Q1603
 USA: LA,http://www.wikidata.org/entity/Q1588
 "USA: New Orleans, LA",https://www.wikidata.org/wiki/Q34404
 USA: MA,http://www.wikidata.org/entity/Q771
+USA: Massachusetts,http://www.wikidata.org/entity/Q771
 USA: MD,http://www.wikidata.org/entity/Q1391
 USA: ME,http://www.wikidata.org/entity/Q724
 USA: MI,http://www.wikidata.org/entity/Q1166
@@ -320,6 +322,7 @@ USA: TN,http://www.wikidata.org/entity/Q1509
 USA: TX,http://www.wikidata.org/entity/Q1439
 USA: UT,http://www.wikidata.org/entity/Q829
 USA: VA,http://www.wikidata.org/entity/Q1370
+USA: Virginia,http://www.wikidata.org/entity/Q1370
 USA: VT,http://www.wikidata.org/entity/Q16551
 USA: WA,http://www.wikidata.org/entity/Q1223
 USA: WI,http://www.wikidata.org/entity/Q1537

--- a/scripts/dict_ontology_standardization/ncbi_countries.csv
+++ b/scripts/dict_ontology_standardization/ncbi_countries.csv
@@ -111,9 +111,11 @@ France,http://www.wikidata.org/entity/Q142
 Gabon,http://www.wikidata.org/entity/Q1000
 Georgia,http://www.wikidata.org/entity/Q230
 Germany,http://www.wikidata.org/entity/Q183
+Germany: Bavaria,https://www.wikidata.org/wiki/Q980
 Germany: Dusseldorf,https://www.wikidata.org/wiki/Q1718
 Ghana,http://www.wikidata.org/entity/Q117
 Greece,http://www.wikidata.org/entity/Q41
+Greece: Athens,https://www.wikidata.org/wiki/Q1524
 Grenada,http://www.wikidata.org/entity/Q769
 Guatemala,http://www.wikidata.org/entity/Q774
 Guinea,http://www.wikidata.org/entity/Q1006
@@ -136,6 +138,8 @@ Ireland,http://www.wikidata.org/entity/Q27
 Israel,http://www.wikidata.org/entity/Q801
 Italy,http://www.wikidata.org/entity/Q38
 Italy: Cagliari,http://www.wikidata.org/entity/Q1897
+Italy: Lazio,https://www.wikidata.org/wiki/Q1282
+Italy: Palermo,https://www.wikidata.org/wiki/Q2656
 Italy: Rome,http://www.wikidata.org/entity/Q220
 Ivory Coast,http://www.wikidata.org/entity/Q1008
 Jamaica,http://www.wikidata.org/entity/Q766
@@ -272,6 +276,7 @@ USA: DC,http://www.wikidata.org/entity/Q3551781
 USA: DE,http://www.wikidata.org/entity/Q1393
 USA: FL,http://www.wikidata.org/entity/Q812
 USA: GA,http://www.wikidata.org/entity/Q1428
+USA: Georgia,http://www.wikidata.org/entity/Q1428
 USA: HI,http://www.wikidata.org/entity/Q782
 USA: IA,http://www.wikidata.org/entity/Q1546
 USA: ID,http://www.wikidata.org/entity/Q1221
@@ -286,6 +291,7 @@ USA: MA,http://www.wikidata.org/entity/Q771
 USA: MD,http://www.wikidata.org/entity/Q1391
 USA: ME,http://www.wikidata.org/entity/Q724
 USA: MI,http://www.wikidata.org/entity/Q1166
+USA: Michigan,http://www.wikidata.org/entity/Q1166
 USA: MN,http://www.wikidata.org/entity/Q1527
 USA: MO,http://www.wikidata.org/entity/Q1581
 USA: MS,http://www.wikidata.org/entity/Q1494
@@ -301,6 +307,7 @@ USA: NV,http://www.wikidata.org/entity/Q1227
 USA: NY,http://www.wikidata.org/entity/Q1384
 USA: New York,http://www.wikidata.org/entity/Q1384
 USA: OH,http://www.wikidata.org/entity/Q1397
+USA: Ohio,http://www.wikidata.org/entity/Q1397
 USA: OK,http://www.wikidata.org/entity/Q1649
 USA: OR,http://www.wikidata.org/entity/Q824
 USA: PA,http://www.wikidata.org/entity/Q1400
@@ -316,6 +323,7 @@ USA: VA,http://www.wikidata.org/entity/Q1370
 USA: VT,http://www.wikidata.org/entity/Q16551
 USA: WA,http://www.wikidata.org/entity/Q1223
 USA: WI,http://www.wikidata.org/entity/Q1537
+USA: Wisconsin,http://www.wikidata.org/entity/Q1537
 USA: WV,http://www.wikidata.org/entity/Q1371
 USA: WY,http://www.wikidata.org/entity/Q1214
 Uzbekistan,http://www.wikidata.org/entity/Q265

--- a/scripts/dict_ontology_standardization/ncbi_sequencing_technology.csv
+++ b/scripts/dict_ontology_standardization/ncbi_sequencing_technology.csv
@@ -1,8 +1,10 @@
 Illumian NextSeq 500,http://www.ebi.ac.uk/efo/EFO_0009173
 Illumina NextSeq 500,http://www.ebi.ac.uk/efo/EFO_0009173
+NextSeq500,http://www.ebi.ac.uk/efo/EFO_0009173
 Nanopore MinION,http://www.ebi.ac.uk/efo/EFO_0008632
 Oxford Nanopore MinION,http://www.ebi.ac.uk/efo/EFO_0008632
 ONT (Oxford Nanopore Technologies),http://purl.obolibrary.org/obo/NCIT_C146818
+Oxford Nanopore Technology,http://purl.obolibrary.org/obo/NCIT_C146818
 Oxford Nanopore technologies MinION,http://www.ebi.ac.uk/efo/EFO_0008632
 MinION Oxford Nanopore,http://www.ebi.ac.uk/efo/EFO_0008632
 Nanopore,http://purl.obolibrary.org/obo/NCIT_C146818

--- a/scripts/dict_ontology_standardization/ncbi_speciesman_source.csv
+++ b/scripts/dict_ontology_standardization/ncbi_speciesman_source.csv
@@ -1,4 +1,5 @@
 nasopharyngeal swab,http://purl.obolibrary.org/obo/NCIT_C155831
+nasopharyngeal swabs,http://purl.obolibrary.org/obo/NCIT_C155831
 nasopharyngeal exudate,http://purl.obolibrary.org/obo/NCIT_C155831
 nasopharyngeal,http://purl.obolibrary.org/obo/NCIT_C155831
 respiratory swab,http://purl.obolibrary.org/obo/NCIT_C155831
@@ -12,10 +13,16 @@ nasopharyngeal (throat) washings,http://purl.obolibrary.org/obo/NCIT_C155831
 oropharyngeal swab,http://purl.obolibrary.org/obo/NCIT_C155835
 throat swab,http://purl.obolibrary.org/obo/NCIT_C155835
 oro-pharyngeal,http://purl.obolibrary.org/obo/NCIT_C155835
+Oropharyngal,http://purl.obolibrary.org/obo/NCIT_C155835
+Oral-pharyngeal,http://purl.obolibrary.org/obo/NCIT_C155835
+Oro-pharyngeal swab,http://purl.obolibrary.org/obo/NCIT_C155835
+Oropharyngeal swab,http://purl.obolibrary.org/obo/NCIT_C155835
+oro pharyngeal swab,http://purl.obolibrary.org/obo/NCIT_C155835
 buccal swab,http://purl.obolibrary.org/obo/NCIT_C155835
 throat washing,http://purl.obolibrary.org/obo/NCIT_C155835
 Throat Swab,http://purl.obolibrary.org/obo/NCIT_C155835
 throat (oropharyngeal) swab,http://purl.obolibrary.org/obo/NCIT_C155835
+Throat (Oropharyngeal) swab,http://purl.obolibrary.org/obo/NCIT_C155835
 bronchoalveolar lavage fluid,http://purl.obolibrary.org/obo/NCIT_C13195
 swab,http://purl.obolibrary.org/obo/NCIT_C13195
 oral swab,http://purl.obolibrary.org/obo/NCIT_C13195

--- a/scripts/from_genbank_to_fasta_and_yaml.py
+++ b/scripts/from_genbank_to_fasta_and_yaml.py
@@ -320,11 +320,9 @@ for path_metadata_xxx_xml in [os.path.join(dir_metadata, name_metadata_xxx_xml) 
                         GBQualifier_value_text = 'China: Hong Kong'
 
                     if GBQualifier_value_text in term_to_uri_dict:
-                        GBQualifier_value_text = term_to_uri_dict[GBQualifier_value_text]
+                        info_for_yaml_dict['sample']['collection_location'] = term_to_uri_dict[GBQualifier_value_text]
                     else:
                         missing_value_list.append('\t'.join([accession_version, GBQualifier_name_text, GBQualifier_value_text]))
-
-                    info_for_yaml_dict['sample']['collection_location'] = GBQualifier_value_text
                 elif GBQualifier_name_text == 'note':
                     if 'additional_collection_information' in info_for_yaml_dict['sample']:
                         info_for_yaml_dict['sample']['additional_collection_information'] += '; ' + GBQualifier_value_text

--- a/scripts/from_genbank_to_fasta_and_yaml.py
+++ b/scripts/from_genbank_to_fasta_and_yaml.py
@@ -8,8 +8,8 @@ import json
 import os
 import requests
 
-from dateutil import parser
 from datetime import date
+from dateutil.parser import parse
 
 num_ids_for_request = 100
 
@@ -312,7 +312,7 @@ for path_metadata_xxx_xml in [os.path.join(dir_metadata, name_metadata_xxx_xml) 
                         GBQualifier_value_text_list = GBQualifier_value_text.split('-')
 
                         if GBQualifier_value_text_list[1].isalpha():
-                            date_to_write = GBQualifier_value_text_list[1] + '-' + GBQualifier_value_text_list[0] + '-' + GBQualifier_value_text_list[2]
+                            date_to_write = parse(GBQualifier_value_text).strftime('%Y-%m-%d')
 
                     info_for_yaml_dict['sample']['collection_date'] = date_to_write
                 elif GBQualifier_name_text in ['lat_lon', 'country']:

--- a/scripts/from_genbank_to_fasta_and_yaml.py
+++ b/scripts/from_genbank_to_fasta_and_yaml.py
@@ -161,7 +161,11 @@ for path_metadata_xxx_xml in [os.path.join(dir_metadata, name_metadata_xxx_xml) 
 
         GBSeq_comment = GBSeq.find('GBSeq_comment')
         if GBSeq_comment is not None and 'Assembly-Data' in GBSeq_comment.text:
-            GBSeq_comment_text = GBSeq_comment.text.split('##Assembly-Data-START## ; ')[1].split(' ; ##Assembly-Data-END##')[0]
+            prefix_split_string = '##Genome-Assembly' if GBSeq_comment.text.startswith('##Genome-') else '##Assembly'
+
+            GBSeq_comment_text = GBSeq_comment.text.split(
+                '{}-Data-START## ; '.format(prefix_split_string)
+            )[1].split(' ; {}-Data-END##'.format(prefix_split_string))[0]
 
             for info_to_check, field_in_yaml in zip(
                 ['Assembly Method', 'Coverage', 'Sequencing Technology'],
@@ -289,9 +293,9 @@ for path_metadata_xxx_xml in [os.path.join(dir_metadata, name_metadata_xxx_xml) 
                     
                     if len(GBQualifier_value_text.split('-')) == 1:
                         if int(GBQualifier_value_text) < 2020:
-                            date_to_write = "15 12 {}".format(GBQualifier_value_text)
+                            date_to_write = "{}-12-15".format(GBQualifier_value_text)
                         else:
-                            date_to_write = "15 01 {}".format(GBQualifier_value_text)
+                            date_to_write = "{}-01-15".format(GBQualifier_value_text)
 
                         if 'additional_collection_information' in info_for_yaml_dict['sample']:
                             info_for_yaml_dict['sample']['additional_collection_information'] += "; The 'collection_date' is estimated (the original date was: {})".format(GBQualifier_value_text)
@@ -308,7 +312,7 @@ for path_metadata_xxx_xml in [os.path.join(dir_metadata, name_metadata_xxx_xml) 
                         GBQualifier_value_text_list = GBQualifier_value_text.split('-')
 
                         if GBQualifier_value_text_list[1].isalpha():
-                            date_to_write = GBQualifier_value_text_list[1] + ' ' + GBQualifier_value_text_list[0] + ' ' + GBQualifier_value_text_list[2]
+                            date_to_write = GBQualifier_value_text_list[1] + '-' + GBQualifier_value_text_list[0] + '-' + GBQualifier_value_text_list[2]
 
                     info_for_yaml_dict['sample']['collection_date'] = date_to_write
                 elif GBQualifier_name_text in ['lat_lon', 'country']:


### PR DESCRIPTION
The NCBI virus entries are updated automatically. Now there are more species and the new metadata cases are managed. The script output should now be more expressive of what's going on, showing also the number of sequences with length greater than or equal to the specified length (27500 base pairs for now).