### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "run = \"<run command here>\" language = \".replit"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # COVID-19 PubSeq: Public Sequence uploader
-
+[![Run on Repl.it](https://repl.it/badge/github/arvados/bh20-seq-resource)](https://repl.it/github/arvados/bh20-seq-resource)
 [![Join the chat at https://gitter.im/arvados/pubseq](https://badges.gitter.im/arvados/pubseq.svg)](https://gitter.im/arvados/pubseq?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 This repository provides a sequence uploader for the COVID-19 Virtual


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).