### PR TITLE
removed double sorting

### DIFF
--- a/workflows/pangenome-generate/odgi-build.cwl
+++ b/workflows/pangenome-generate/odgi-build.cwl
@@ -21,6 +21,6 @@ hints:
     listing:
       - entry: $(inputs.inputGFA)
         writable: true
-arguments: [odgi, build, -g, $(inputs.inputGFA), -s, -o, -,
+arguments: [odgi, build, -g, $(inputs.inputGFA), -o, -,
             {shellQuote: false, valueFrom: "|"},
             odgi, sort, -i, -, -p, s, -o, $(inputs.inputGFA.nameroot).odgi]


### PR DESCRIPTION
The -s argument in odgi build does the same topological sort that odgi sort -p s does.