### PR TITLE
added the assembly_method field 

### DIFF
--- a/bh20sequploader/bh20seq-schema.yml
+++ b/bh20sequploader/bh20seq-schema.yml
@@ -178,6 +178,11 @@ $graph:
 - name: technologySchema
   type: record
   fields:
+    assembly_method:
+      doc: Assembly method refers to how the reads were assembled into contigs for which either a de novo or mapping (reference based) strategy is used.
+      type: string
+      jsonldPredicate:
+        _id: http://purl.obolibrary.org/obo/GENEPIO_0000090
     sample_sequencing_technology:
       doc: Technology that was used to sequence this sample (e.g Sanger, Nanopor MiniION)
       type: string[]


### PR DESCRIPTION
This allow us to distinguish formally de-novo assemblies from reference-based approaches.

We can use [this](http://purl.obolibrary.org/obo/GENEPIO_0000090) ontology, with these two IRIs:
- http://purl.obolibrary.org/obo/GENEPIO_0001628 for de-novo assembly
- http://purl.obolibrary.org/obo/GENEPIO_0002028 for mapping_reference_based
